### PR TITLE
Docker Image - Containerizing Pi Weather Station

### DIFF
--- a/Docker Hub
+++ b/Docker Hub
@@ -1,1 +1,0 @@
-https://hub.docker.com/repository/docker/seanriggs/pi-weather-station

--- a/Docker Hub
+++ b/Docker Hub
@@ -1,0 +1,1 @@
+https://hub.docker.com/repository/docker/seanriggs/pi-weather-station

--- a/Docker Image/Docker Hub Link.txt
+++ b/Docker Image/Docker Hub Link.txt
@@ -1,0 +1,1 @@
+https://hub.docker.com/repository/docker/seanriggs/pi-weather-station

--- a/Docker Image/Docker YML AMD64/docker-compose.yml
+++ b/Docker Image/Docker YML AMD64/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  weather-station:
+    image: seanriggs/pi-weather-station:latest
+    container_name: weather-station
+    ports:
+      - "8080:8080"
+    volumes:
+      - appdata:/app
+    restart: unless-stopped
+volumes:
+  appdata:

--- a/Docker Image/Docker YML ARM/docker-compose.yml
+++ b/Docker Image/Docker YML ARM/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  weather-station:
+    image: seanriggs/pi-weather-station:arm64
+    container_name: weather-station
+    ports:
+      - "8080:8080"
+    volumes:
+      - appdata:/app
+    restart: unless-stopped
+volumes:
+  appdata:

--- a/Docker Image/Docker YML ARMv7/docker-compose.yml
+++ b/Docker Image/Docker YML ARMv7/docker-compose.yml
@@ -1,0 +1,13 @@
+
+version: '3'
+services:
+  weather-station:
+    image: seanriggs/pi-weather-station:armv7-armhf
+    container_name: weather-station
+    ports:
+      - "8080:8080"
+    volumes:
+      - appdata:/app
+    restart: unless-stopped
+volumes:
+  appdata:

--- a/Docker Image/Docker-ReadMe.md
+++ b/Docker Image/Docker-ReadMe.md
@@ -1,0 +1,76 @@
+# Pi Weather Station *DOCKERIZED*
+
+This Docker Image is a containerized application originally built by Eric Elewin. Containerizing his application captures all the dependencies required to make it run. Launching the application in Docker allows for easy deployment!
+
+These Docker images will work on RaspberryPi still but is also built to work on AMD64 infrastructure, depending on the tag you specify of course ;)
+
+Just so you know, the original application was pre-configured to access the application from the hosting machine only. I have modified index.js to allow any machine on the local network to access the application from the web browser. By exposing the app to your entire network, users on that network access the app and retrieve your API keys from the settings page. I use this at home with my family, so I am ok with that risk. 
+
+Eric developed this application as a weather station running on RaspberryPI on the official 7" 800x480 touchscreen. See Eric's Github located here: https://github.com/elewin/pi-weather-station#pi-weather-station 
+
+![Pi Weather Station ](https://user-images.githubusercontent.com/15202038/91359998-4625bb80-e7bb-11ea-937e-c87eede41f35.JPG)
+
+Compiled app data to run as a lightweight container in docker. Uses Node:12.12-alpine.
+
+Images will work on ARM/aarch64 and x86 Linux/AMD infrastructure. 
+
+The compose file example will be below and includes an example for persistent volumes, so API data is recovered on container recreation. 
+
+Options will allow you to run on any physical Linux machine (including RaspberryPi), Virtual Machines, or Windows. Tested on Windows 10, Debian, and Ubuntu.
+
+<table>
+<tr>
+<th>Architecture</th>
+<th>Available</th>	
+</tr>
+<tr>
+<td>amd64</td>
+<td>✅</td>
+</tr>
+<tr>	
+<td>arm64</td>
+<td>✅</td>
+</tr>
+<tr>
+<td>arm64v8</td>
+<td>✅</td>
+</table>
+
+<strong>Docker Run</strong>
+
+You can spin up the container using docker run with the following example below:
+
+Create a Docker Volume first so that you can save persistent API Data:
+```bash
+docker volume create appdata
+```
+Using the volume example above, create the container and pull the image: 
+
+```bash
+docker run -itd --name weather-station -p 8080:8080 -v appdata:/app seanriggs/pi-weather-station
+```
+Remember to specify the arm64 tag if you use an arm or aarch64 based infrastructure.
+
+![Docker Compose ](https://user-images.githubusercontent.com/111924572/188755814-af9ef5fd-9aa5-44a4-81dc-47bf7a1a5849.png)
+## docker-compose.yml
+```docker
+version: '3'
+services:
+  weather-station:
+    image: seanriggs/pi-weather-station:latest #or arm64 (i.e. RaspberryPi)
+    container_name: weather-station
+    ports:
+      - "8080:8080"
+    volumes:
+      - appdata:/app
+    restart: unless-stopped
+volumes:
+  appdata:
+```
+# Bringing up with Docker-Compose
+
+The docker-compose command will pull the image based on the updated docker-compose.yml file you saved from above. The file should be ready to go in the directory you chose for it (i.e. pi-weather-station). The next step is to spin up your containers using docker-compose and starting the docker daemon:
+
+```bash
+docker-compose up -d
+```

--- a/Docker Image/Docker-ReadMe.md
+++ b/Docker Image/Docker-ReadMe.md
@@ -34,6 +34,13 @@ Options will allow you to run on any physical Linux machine (including Raspberry
 <tr>
 <td>arm64v8</td>
 <td>✅</td>
+</tr>
+<tr>
+<td>armhf</td>
+<td>✅</td>
+</tr>
+<td>arm32v7</td>
+<td>✅	</td>
 </table>
 
 <strong>Docker Run</strong>

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ The server will now serve the app across your network.
 
 # Do you want to Host this Application in Docker?
 
-Pi Weather Station is available as a Docker Image for AMD64 and ARM infrastructures. see the *ReadME here for more: https://github.com/SeanRiggs/pi-weather-station/blob/master/Docker%20Image/Docker-ReadMe.md
+Pi Weather Station is available as a Docker Image for AMD64 and ARM infrastructures. see the *ReadME* here for more: https://github.com/SeanRiggs/pi-weather-station/blob/master/Docker%20Image/Docker-ReadMe.md
 
 # License
 

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,10 @@ The server will now serve the app across your network.
 - The server will attempt to get your default location, but if it cannot or you wish to choose a different default location, enter the latitude and longitude under `Custom Latitude` and `Custom Longitude` in settings, which can be accessed by tapping the gear button in the lower right hand corner.
 - To hide the mouse cursor when using a touch screen, set `Hide Mouse` to `On`.
 
+# Do you want to Host this Application in Docker?
+
+Pi Weather Station is available as a Docker Image for AMD64 and ARM infrastructures. see the *ReadME here for more: https://github.com/SeanRiggs/pi-weather-station/blob/master/Docker%20Image/Docker-ReadMe.md
+
 # License
 
 The MIT License (MIT)


### PR DESCRIPTION
This Docker Image is a containerized application originally built by Eric Elewin. Containerizing his application captures all the dependencies required to make it run. Launching the application in Docker allows for easy deployment!

These Docker images will work on RaspberryPi still but is also built to work on AMD64 infrastructure, depending on the tag you specify of course ;)

Just so you know, the original application was pre-configured to access the application from the hosting machine only. I have modified index.js to allow any machine on the local network to access the application from the web browser. By exposing the app to your entire network, users on that network access the app and retrieve your API keys from the settings page. I use this at home with my family, so I am ok with that risk.

Link to my Docker Hub with images as well: https://hub.docker.com/repository/docker/seanriggs/pi-weather-station